### PR TITLE
A modular debugging system that can be turned off at build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         go-version: 1.19
     - name: Build Windows exe
       shell: bash
-      run: go build
+      run: go build -tags release
     - name: Upload Windows exe
       uses: actions/upload-artifact@v3
       with:
@@ -51,7 +51,7 @@ jobs:
         go-version: 1.19
     - name: Build Mac exe
       shell: bash
-      run: go build
+      run: go build -tags release
     - name: Tar it up
       shell: bash
       run: tar -zcvf escort-mission-mac.tar.gz escort-mission LICENSE
@@ -76,7 +76,7 @@ jobs:
       run: sudo apt-get -y install libgl1-mesa-dev xorg-dev libasound2-dev
     - name: Build Linux exe
       shell: bash
-      run: go build -v
+      run: go build -v -tags release
     - name: Tar it up
       shell: bash
       run: tar -zcvf escort-mission-lin.tar.gz escort-mission LICENSE
@@ -98,7 +98,7 @@ jobs:
         go-version: 1.19
     - name: Build Web binary
       shell: bash
-      run: GOOS=js GOARCH=wasm go build -v -ldflags "-w -s" -o dist/web/escort-mission.wasm
+      run: GOOS=js GOARCH=wasm go build -v -ldflags "-w -s" -o dist/web/escort-mission.wasm -tags release
     - name: Copy WASM exec script
       shell: bash
       run: cp $(go env GOROOT)/misc/wasm/wasm_exec.js dist/web/.

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+// Debugger provides debug information by rendering it on-screen
+type Debugger interface {
+	Debug(g *Game, screen *ebiten.Image)
+}
+
+// DebugFunc implements the Debugger interface
+type DebugFunc func(g *Game, screen *ebiten.Image)
+
+// Debug calls the debug callback with the provided arguments
+func (f DebugFunc) Debug(g *Game, screen *ebiten.Image) {
+	f(g, screen)
+}
+
+// DebugText prints out general debug information as text
+func DebugText(g *Game, screen *ebiten.Image) {
+	ebitenutil.DebugPrint(screen, fmt.Sprintf(
+		"FPS: %.2f\n"+
+			"TPS: %.2f\n"+
+			"X: %.2f\n"+
+			"Y: %.2f\n"+
+			"Zombies: %d\n",
+		ebiten.ActualFPS(),
+		ebiten.ActualTPS(),
+		g.Player.Object.X/32,
+		g.Player.Object.Y/32,
+		len(g.Zombies),
+	))
+}

--- a/debug.go
+++ b/debug.go
@@ -22,6 +22,21 @@ func (f DebugFunc) Debug(g *Game, screen *ebiten.Image) {
 	f(g, screen)
 }
 
+// Debuggers is a slice of a Debugger to make it easier to handle many debuggers
+type Debuggers []Debugger
+
+// Debug passes on the Debug call to all its child Debuggers
+func (ds Debuggers) Debug(g *Game, screen *ebiten.Image) {
+	for _, d := range ds {
+		d.Debug(g, screen)
+	}
+}
+
+// Add is a shorthand for adding a child Debugger to the Debuggers
+func (ds *Debuggers) Add(d Debugger) {
+	*ds = append(*ds, d)
+}
+
 // DebugText prints out general debug information as text
 func DebugText(g *Game, screen *ebiten.Image) {
 	ebitenutil.DebugPrint(screen, fmt.Sprintf(

--- a/debug.go
+++ b/debug.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"image/color"
+	"math"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
@@ -34,4 +36,18 @@ func DebugText(g *Game, screen *ebiten.Image) {
 		g.Player.Object.Y/32,
 		len(g.Zombies),
 	))
+}
+
+// DebugAim draws a line showing the direction and range of the gun
+func DebugAim(g *Game, screen *ebiten.Image) {
+	rangeOfFire := g.Player.Range
+	sX, sY := g.Camera.GetScreenCoords(
+		g.Player.Object.X-math.Cos(g.Player.Angle-math.Pi)*rangeOfFire,
+		g.Player.Object.Y-math.Sin(g.Player.Angle-math.Pi)*rangeOfFire,
+	)
+	pX, pY := g.Camera.GetScreenCoords(
+		g.Player.Object.X+g.Player.Object.W/2,
+		g.Player.Object.Y+g.Player.Object.H/2,
+	)
+	ebitenutil.DrawLine(screen, pX, pY, sX, sY, color.Black)
 }

--- a/debug.go
+++ b/debug.go
@@ -1,13 +1,14 @@
+// Copyright 2021 Siôn le Roux.  All rights reserved.
+// Use of this source code is subject to an MIT-style
+// licence which can be found in the LICENSE file.
+
 package main
 
 import (
-	"fmt"
-	"image/color"
-	"math"
-
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
+
+var debuggers Debuggers
 
 // Debugger provides debug information by rendering it on-screen
 type Debugger interface {
@@ -35,34 +36,4 @@ func (ds Debuggers) Debug(g *Game, screen *ebiten.Image) {
 // Add is a shorthand for adding a child Debugger to the Debuggers
 func (ds *Debuggers) Add(d Debugger) {
 	*ds = append(*ds, d)
-}
-
-// DebugText prints out general debug information as text
-func DebugText(g *Game, screen *ebiten.Image) {
-	ebitenutil.DebugPrint(screen, fmt.Sprintf(
-		"FPS: %.2f\n"+
-			"TPS: %.2f\n"+
-			"X: %.2f\n"+
-			"Y: %.2f\n"+
-			"Zombies: %d\n",
-		ebiten.ActualFPS(),
-		ebiten.ActualTPS(),
-		g.Player.Object.X/32,
-		g.Player.Object.Y/32,
-		len(g.Zombies),
-	))
-}
-
-// DebugAim draws a line showing the direction and range of the gun
-func DebugAim(g *Game, screen *ebiten.Image) {
-	rangeOfFire := g.Player.Range
-	sX, sY := g.Camera.GetScreenCoords(
-		g.Player.Object.X-math.Cos(g.Player.Angle-math.Pi)*rangeOfFire,
-		g.Player.Object.Y-math.Sin(g.Player.Angle-math.Pi)*rangeOfFire,
-	)
-	pX, pY := g.Camera.GetScreenCoords(
-		g.Player.Object.X+g.Player.Object.W/2,
-		g.Player.Object.Y+g.Player.Object.H/2,
-	)
-	ebitenutil.DrawLine(screen, pX, pY, sX, sY, color.Black)
 }

--- a/debugaim.go
+++ b/debugaim.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Siôn le Roux.  All rights reserved.
+// Use of this source code is subject to an MIT-style
+// licence which can be found in the LICENSE file.
+
+//go:build !release
+
+package main
+
+import (
+	"image/color"
+	"math"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+func init() {
+	debuggers.Add(DebugFunc(DebugAim))
+}
+
+// DebugAim draws a line showing the direction and range of the gun
+func DebugAim(g *Game, screen *ebiten.Image) {
+	rangeOfFire := g.Player.Range
+	sX, sY := g.Camera.GetScreenCoords(
+		g.Player.Object.X-math.Cos(g.Player.Angle-math.Pi)*rangeOfFire,
+		g.Player.Object.Y-math.Sin(g.Player.Angle-math.Pi)*rangeOfFire,
+	)
+	pX, pY := g.Camera.GetScreenCoords(
+		g.Player.Object.X+g.Player.Object.W/2,
+		g.Player.Object.Y+g.Player.Object.H/2,
+	)
+	ebitenutil.DrawLine(screen, pX, pY, sX, sY, color.Black)
+}

--- a/debugtext.go
+++ b/debugtext.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Siôn le Roux.  All rights reserved.
+// Use of this source code is subject to an MIT-style
+// licence which can be found in the LICENSE file.
+
+//go:build !release
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+func init() {
+	debuggers.Add(DebugFunc(DebugText))
+}
+
+// DebugText prints out general debug information as text
+func DebugText(g *Game, screen *ebiten.Image) {
+	ebitenutil.DebugPrint(screen, fmt.Sprintf(
+		"FPS: %.2f\n"+
+			"TPS: %.2f\n"+
+			"X: %.2f\n"+
+			"Y: %.2f\n"+
+			"Zombies: %d\n",
+		ebiten.ActualFPS(),
+		ebiten.ActualTPS(),
+		g.Player.Object.X/32,
+		g.Player.Object.Y/32,
+		len(g.Zombies),
+	))
+}

--- a/main.go
+++ b/main.go
@@ -157,6 +157,7 @@ func NewGame(g *Game) {
 	}
 
 	g.Debuggers = append(g.Debuggers, DebugFunc(DebugText))
+	g.Debuggers = append(g.Debuggers, DebugFunc(DebugAim))
 }
 
 // Layout is hardcoded for now, may be made dynamic in future

--- a/main.go
+++ b/main.go
@@ -6,12 +6,10 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"math"
 
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	camera "github.com/melonfunction/ebiten-camera"
 	"github.com/solarlune/ldtkgo"
@@ -61,7 +59,7 @@ type Game struct {
 	Dog          *Dog
 	Zombies      Zombies
 	Space        *resolv.Space
-	Debuggers    []func(g *Game, screen *ebiten.Image)
+	Debuggers    []Debugger
 }
 
 // NewGame fills up the main Game data with assets, entities, pre-generated
@@ -158,20 +156,7 @@ func NewGame(g *Game) {
 		}
 	}
 
-	g.Debuggers = append(g.Debuggers, func(g *Game, screen *ebiten.Image) {
-		ebitenutil.DebugPrint(screen, fmt.Sprintf(
-			"FPS: %.2f\n"+
-				"TPS: %.2f\n"+
-				"X: %.2f\n"+
-				"Y: %.2f\n"+
-				"Zombies: %d\n",
-			ebiten.ActualFPS(),
-			ebiten.ActualTPS(),
-			g.Player.Object.X/32,
-			g.Player.Object.Y/32,
-			len(g.Zombies),
-		))
-	})
+	g.Debuggers = append(g.Debuggers, DebugFunc(DebugText))
 }
 
 // Layout is hardcoded for now, may be made dynamic in future
@@ -244,7 +229,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	g.Camera.Blit(screen)
 
 	for _, fn := range g.Debuggers {
-		fn(g, screen)
+		fn.Debug(g, screen)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ type Game struct {
 	Dog          *Dog
 	Zombies      Zombies
 	Space        *resolv.Space
-	Debuggers    []Debugger
+	Debuggers    Debuggers
 }
 
 // NewGame fills up the main Game data with assets, entities, pre-generated
@@ -156,8 +156,8 @@ func NewGame(g *Game) {
 		}
 	}
 
-	g.Debuggers = append(g.Debuggers, DebugFunc(DebugText))
-	g.Debuggers = append(g.Debuggers, DebugFunc(DebugAim))
+	g.Debuggers.Add(DebugFunc(DebugText))
+	g.Debuggers.Add(DebugFunc(DebugAim))
 }
 
 // Layout is hardcoded for now, may be made dynamic in future
@@ -229,9 +229,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 	g.Camera.Blit(screen)
 
-	for _, fn := range g.Debuggers {
-		fn.Debug(g, screen)
-	}
+	g.Debuggers.Debug(g, screen)
 }
 
 // Clicked is shorthand for when the left mouse button has just been clicked

--- a/main.go
+++ b/main.go
@@ -31,10 +31,11 @@ func main() {
 	ebiten.SetFPSMode(ebiten.FPSModeVsyncOffMaximum)
 
 	game := &Game{
-		Width:  gameWidth,
-		Height: gameHeight,
-		Level:  0,
-		Tick:   0,
+		Width:     gameWidth,
+		Height:    gameHeight,
+		Level:     0,
+		Tick:      0,
+		Debuggers: debuggers,
 	}
 
 	go NewGame(game)
@@ -155,9 +156,6 @@ func NewGame(g *Game) {
 			g.Zombies = append(g.Zombies, z)
 		}
 	}
-
-	g.Debuggers.Add(DebugFunc(DebugText))
-	g.Debuggers.Add(DebugFunc(DebugAim))
 }
 
 // Layout is hardcoded for now, may be made dynamic in future

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ type Game struct {
 	Dog          *Dog
 	Zombies      Zombies
 	Space        *resolv.Space
+	Debuggers    []func(g *Game, screen *ebiten.Image)
 }
 
 // NewGame fills up the main Game data with assets, entities, pre-generated
@@ -156,6 +157,21 @@ func NewGame(g *Game) {
 			g.Zombies = append(g.Zombies, z)
 		}
 	}
+
+	g.Debuggers = append(g.Debuggers, func(g *Game, screen *ebiten.Image) {
+		ebitenutil.DebugPrint(screen, fmt.Sprintf(
+			"FPS: %.2f\n"+
+				"TPS: %.2f\n"+
+				"X: %.2f\n"+
+				"Y: %.2f\n"+
+				"Zombies: %d\n",
+			ebiten.ActualFPS(),
+			ebiten.ActualTPS(),
+			g.Player.Object.X/32,
+			g.Player.Object.Y/32,
+			len(g.Zombies),
+		))
+	})
 }
 
 // Layout is hardcoded for now, may be made dynamic in future
@@ -227,18 +243,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 	g.Camera.Blit(screen)
 
-	ebitenutil.DebugPrint(screen, fmt.Sprintf(
-		"FPS: %.2f\n"+
-			"TPS: %.2f\n"+
-			"X: %.2f\n"+
-			"Y: %.2f\n"+
-			"Zombies: %d\n",
-		ebiten.ActualFPS(),
-		ebiten.ActualTPS(),
-		g.Player.Object.X/32,
-		g.Player.Object.Y/32,
-		len(g.Zombies),
-	))
+	for _, fn := range g.Debuggers {
+		fn(g, screen)
+	}
 }
 
 // Clicked is shorthand for when the left mouse button has just been clicked


### PR DESCRIPTION
The goal was:
- no more writing in Game.Draw() to print out some stuff to the screen and then forgetting to remove it, or keep needing to go back in the commit history to put it back because you need it again to test something
- just write it as a Debugger and leave it there
- all Debuggers will be removed from the game build that ships from Github but are usable in your local version

This is not yet done because I don't like the many debug files here at the top level and I would like the debugging somehow to be managed by the things that make it. E.g. you are working on dog and want to debug it, so you write that code inside dog.go and leave it there. For the production release version it is not included, so you don't have to care.